### PR TITLE
Add deploy checker

### DIFF
--- a/deploy_checker.py
+++ b/deploy_checker.py
@@ -1,0 +1,30 @@
+import os
+import pickle
+from subprocess import run, CalledProcessError
+
+import requests
+
+DEPLOY_TOKEN = 'a66ddccc06f682bdefee2d0964ee676c87dfc7ca'
+
+most_recent_commit = ''
+if os.path.exists('most_recent_commit.pkl'):
+    most_recent_commit = pickle.load(open('most_recent_commit.pkl', 'rb'))
+
+r = requests.get('http://api.github.com/repos/danthe96/mpci/commits/master', auth=('mpci-deploy-user', DEPLOY_TOKEN))
+current_commit = r.json()['sha']
+
+if current_commit != most_recent_commit:
+    r = requests.get('https://api.github.com/repos/danthe96/mpci/commits/{}/check-runs'.format(current_commit),
+                     auth=('mpci-deploy-user', DEPLOY_TOKEN), params={'status': 'completed'},
+                     headers={'Accept': 'application/vnd.github.antiope-preview+json'})
+    checks = r.json()
+    if any([c['conclusion'] == 'success' for c in checks['check_runs']]):
+        print('Alright folks, time to deploy!')
+        print('Old commit was {}, new one is {}'.format(most_recent_commit, current_commit))
+        pickle.dump(current_commit, open('most_recent_commit.pkl', 'wb'))
+
+        try:
+            run('git pull && docker-compose down && docker-compose build && docker-compose up --detach',
+                shell=True, check=True)
+        except CalledProcessError:
+            os.remove('most_recent_commit.pkl')


### PR DESCRIPTION
Add python script which, when run on our deploy server as cron job, will check if master has a new (passing!) commit and redeploy. Already tested and working. 
Example: 
```
deploy@vm-mpws2018-proj:~/mpci$ python3 deploy_checker.py 
Alright folks, time to deploy!
Old commit was , new one is d7219413d7e7d3c53a950990cd5a9eb83d7260c3
Already up to date.
Stopping mpci_backend_1_be227939c0e1  ... done
Stopping mpci_database_1_30cbd1fe3181 ... done
Removing mpci_db-ui_1_99e5347f3cc9    ... done
Removing mpci_backend_1_be227939c0e1  ... done
Removing mpci_database_1_30cbd1fe3181 ... done
Removing network mpci_default
database uses an image, skipping
db-ui uses an image, skipping
Building backend
Step 1/8 : FROM danthe1/mpci_backend:latest
 ---> 82486317b0b4
Step 2/8 : COPY requirements.txt /app/
 ---> Using cache
 ---> 41a40d56a96b
Step 3/8 : COPY requirements.r /app/
 ---> Using cache
 ---> 125505fb5d22
Step 4/8 : WORKDIR /app
 ---> Using cache
 ---> af5e6cb0a434
Step 5/8 : RUN Rscript requirements.r
 ---> Using cache
 ---> fe278899de77
Step 6/8 : RUN pip install -r requirements.txt
 ---> Using cache
 ---> 8613b562bb54
Step 7/8 : COPY . .
 ---> 82fb4681f869
Step 8/8 : CMD ["python", "server.py"]
 ---> Running in 852e0cc02e59
Removing intermediate container 852e0cc02e59
 ---> ca0b08d088f8
Successfully built ca0b08d088f8
Successfully tagged mpci_backend:latest
Creating network "mpci_default" with the default driver
Creating mpci_database_1_2c03c2c40d58 ... done
Creating mpci_backend_1_2a2d9d5c838e  ... done
Creating mpci_db-ui_1_99ef6965bda3    ... done
deploy@vm-mpws2018-proj:~/mpci$ 
```