### PR TITLE
Deactivate validator in swagger-ui

### DIFF
--- a/static/ui/index.html
+++ b/static/ui/index.html
@@ -49,7 +49,8 @@
         plugins: [
           SwaggerUIBundle.plugins.DownloadUrl
         ],
-        layout: "StandaloneLayout"
+        layout: "StandaloneLayout",
+        validatorUrl: null
       })
       // End Swagger UI call region
 


### PR DESCRIPTION
Validation doesn't work because host is not reachable.