### PR TITLE
Better categorical histograms

### DIFF
--- a/src/master/resources/distributions.py
+++ b/src/master/resources/distributions.py
@@ -22,7 +22,7 @@ class ContinuousDistributionSchema(DistributionSchema):
 
 
 class DiscreteDistributionSchema(DistributionSchema):
-    bins = fields.Dict(values=fields.Int())
+    bins = fields.Dict(values=fields.Int(), keys=fields.String())
 
 
 class MarginalDistributionResource(Resource):
@@ -57,7 +57,7 @@ class MarginalDistributionResource(Resource):
         values = [line[0] for line in result]
 
         if len(np.unique(values)) <= 10:  # Categorical
-            bins = dict(zip(*np.unique(values, return_counts=True)))
+            bins = dict([(str(k), int(v)) for k, v in zip(*np.unique(values, return_counts=True))])
             return marshal(DiscreteDistributionSchema, {
                 'node': node,
                 'dataset': dataset,

--- a/test/unit/master/resources/test_distributions.py
+++ b/test/unit/master/resources/test_distributions.py
@@ -70,6 +70,6 @@ class DistributionTest(BaseResourceTest):
             # Then
             assert distribution['node']['id'] == node.id
             assert distribution['dataset']['id'] == ds.id
-            bins = dict(zip(*np.unique(source[:, 0], return_counts=True)))
+            bins = dict([(str(k), int(v)) for k, v in zip(*np.unique(source[:, 0], return_counts=True))])
             assert distribution['bins'] == bins
             assert 'bin_edges' not in distribution


### PR DESCRIPTION
If the distribution is categorical, there is no `bin_edges` and `bins` is a dictionary mapping values to counts. Makes for cleaner charts.