### PR TITLE
Add Support for KCIT via pcalg

### DIFF
--- a/services/executionenvironments/r/executor/kcit_wrapper.r
+++ b/services/executionenvironments/r/executor/kcit_wrapper.r
@@ -1,0 +1,9 @@
+library(RCIT)
+
+kcitWrapper <- function(x,y,z, suffStat) {
+	if (identical(z, integer(0))) {
+		U_KCI(as.vector(t(suffStat$dm[x])),as.vector(t(suffStat$dm[y])))
+	} else {
+		KCIT(suffStat$dm[x],suffStat$dm[y],suffStat$dm[z])
+	}
+}

--- a/services/executionenvironments/r/executor/pcalg_pc.r
+++ b/services/executionenvironments/r/executor/pcalg_pc.r
@@ -19,6 +19,7 @@ source("/scripts/CMI-adaptive-hist/algorithm/CMI_estimates.R")
 source("/scripts/CMI-adaptive-hist/algorithm/CMI_pvals.R")
 source("/scripts/CMI-adaptive-hist/algorithm/utils.R")
 
+source("/scripts/kcit_wrapper.r")
 
 option_list_v <- list(
                     make_option(c("-j", "--job_id"), type="character",
@@ -55,7 +56,8 @@ option_list_v <- list(
 );
 
 indepTestDict <- list(gaussCI=gaussCItest, binCI=binCItest, disCI=disCItest,
-                    CMIpqNML=CMIp.qNML, CMIpfNML=CMIp.fNML, CMIpChisq99=CMIp.Chisq99, CMIpChisq95=CMIp.Chisq95)
+                    CMIpqNML=CMIp.qNML, CMIpfNML=CMIp.fNML, CMIpChisq99=CMIp.Chisq99, CMIpChisq95=CMIp.Chisq95,
+                    KCIT=kcitWrapper)
 
 option_parser <- OptionParser(option_list=option_list_v)
 opt <- parse_args(option_parser)
@@ -94,6 +96,8 @@ if (opt$independence_test == "gaussCI") {
         }
     }
     sufficient_stats = list(dm=matrix_df, type=type, n=nrow(df))
+} else if (opt$independence_test == "KCIT") {
+    sufficient_stats <- list(dm=df)
 } else {
     stop("No valid independence test specified")
 }

--- a/services/python-images/conf/algorithms.json
+++ b/services/python-images/conf/algorithms.json
@@ -15,7 +15,7 @@
       "independence_test": {
         "type": "enum",
         "required": true,
-        "values": ["gaussCI", "disCI", "binCI", "CMIpqNML", "CMIpfNML", "CMIpChisq99", "CMIpChisq95"]
+        "values": ["gaussCI", "disCI", "binCI", "CMIpqNML", "CMIpfNML", "CMIpChisq99", "CMIpChisq95", "KCIT"]
       },
       "discrete_limit": {
         "type": "int",


### PR DESCRIPTION
- added a wrapper function to call the appropriate version (no conditioning, conditioning) of KCIT.
- option is added as CI test for pcalg